### PR TITLE
git_helpers: add fallback for inconsistent describe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: |
+          python -m pip install pytest
+          python -m pytest
+
   build:
     strategy:
       fail-fast: false

--- a/conda_build_prepare/git_helpers.py
+++ b/conda_build_prepare/git_helpers.py
@@ -148,7 +148,11 @@ def _call_custom_git_cmd(git_repo, cmd_string, check=True, quiet=False):
 def get_latest_describe_tag(git_repo):
     # Find the `git describe` tag having any version-like part
     try:
-        return _call_custom_git_cmd(git_repo, 'describe --tags --abbrev=0', quiet=True)
+        describe_tag = _call_custom_git_cmd(git_repo, 'describe --tags --abbrev=0', quiet=True)
+        tag_commit = _call_custom_git_cmd(git_repo, f'git rev-list --tags -1')
+        alt_tag = _call_custom_git_cmd(git_repo, f'tag --points-at {tag_commit}')
+        # Prefer actual tag over `git describe' if inconsistent.
+        return describe_tag if describe_tag.startswith(alt_tag) else alt_tag
     except subprocess.CalledProcessError:
         return None
 

--- a/conda_build_prepare/git_helpers.py
+++ b/conda_build_prepare/git_helpers.py
@@ -145,14 +145,11 @@ def _call_custom_git_cmd(git_repo, cmd_string, check=True, quiet=False):
     return stdout.strip()
 
 
-def get_latest_describe_tag(git_repo):
-    # Find the `git describe` tag having any version-like part
+def get_latest_tag(git_repo):
     try:
-        describe_tag = _call_custom_git_cmd(git_repo, 'describe --tags --abbrev=0', quiet=True)
-        tag_commit = _call_custom_git_cmd(git_repo, f'git rev-list --tags -1')
-        alt_tag = _call_custom_git_cmd(git_repo, f'tag --points-at {tag_commit}')
-        # Prefer actual tag over `git describe' if inconsistent.
-        return describe_tag if describe_tag.startswith(alt_tag) else alt_tag
+        tag_commit = _call_custom_git_cmd(git_repo, f'rev-list --tags -1')
+        tag_refname = _call_custom_git_cmd(git_repo, f'tag --points-at {tag_commit}')
+        return tag_refname
     except subprocess.CalledProcessError:
         return None
 
@@ -236,7 +233,7 @@ def git_rewrite_tags(git_repo):
     print(f'\nRewriting tags in "{os.path.abspath(git_repo)}"...\n')
 
     while True:
-        tag = get_latest_describe_tag(git_repo)
+        tag = get_latest_tag(git_repo)
         if tag is None:
             # Add '0.0' tag on initial commit and skip rewriting.
             git_add_initial_tag(git_repo)

--- a/conda_build_prepare/git_helpers.py
+++ b/conda_build_prepare/git_helpers.py
@@ -145,11 +145,11 @@ def _call_custom_git_cmd(git_repo, cmd_string, check=True, quiet=False):
     return stdout.strip()
 
 
-def get_latest_tag(git_repo):
+def get_first_reachable_tag(git_repo):
     try:
-        tag_commit = _call_custom_git_cmd(git_repo, f'rev-list --tags -1')
-        tag_refname = _call_custom_git_cmd(git_repo, f'tag --points-at {tag_commit}')
-        return tag_refname
+        # list reachable tag sorted by commit date
+        tags = _call_custom_git_cmd(git_repo, 'tag --merged').splitlines()
+        return tags[-1]
     except subprocess.CalledProcessError:
         return None
 
@@ -233,7 +233,7 @@ def git_rewrite_tags(git_repo):
     print(f'\nRewriting tags in "{os.path.abspath(git_repo)}"...\n')
 
     while True:
-        tag = get_latest_tag(git_repo)
+        tag = get_first_reachable_tag(git_repo)
         if tag is None:
             # Add '0.0' tag on initial commit and skip rewriting.
             git_add_initial_tag(git_repo)

--- a/test/test_git_helpers.py
+++ b/test/test_git_helpers.py
@@ -19,6 +19,12 @@ def git_commit_and_tag(filepath, msg, tag=None):
 def test_get_first_reachable_tag(tmp_path):
     repo = tmp_path
     gh._call_custom_git_cmd(repo, 'init -b main')
+    gh._call_custom_git_cmd(
+        repo, 'config --local user.email "you@example.com"'
+    )
+    gh._call_custom_git_cmd(
+        repo, 'config --local user.name "Your Name"'
+    )
     git_commit_and_tag(repo / 'foo', 'first', tag=None)
 
     initial_rev = gh._call_custom_git_cmd(repo, 'rev-parse HEAD')

--- a/test/test_git_helpers.py
+++ b/test/test_git_helpers.py
@@ -1,4 +1,3 @@
-import pathlib
 import time
 
 import conda_build_prepare.git_helpers as gh

--- a/test/test_git_helpers.py
+++ b/test/test_git_helpers.py
@@ -1,0 +1,38 @@
+import pathlib
+import time
+
+import conda_build_prepare.git_helpers as gh
+
+COMMIT_DELAY = 1
+
+
+def git_commit_and_tag(filepath, msg, tag=None):
+    now = time.time()
+    with open(filepath, 'w') as f:
+        f.write(f'{now}')
+    gh._call_custom_git_cmd(filepath.parent, f'add {filepath}')
+    gh._call_custom_git_cmd(filepath.parent, f'commit -m {msg}')
+    if tag:
+        gh._call_custom_git_cmd(filepath.parent, f'tag {tag}')
+    time.sleep(COMMIT_DELAY)
+
+
+def test_get_first_reachable_tag(tmp_path):
+    repo = tmp_path
+    gh._call_custom_git_cmd(repo, 'init -b main')
+    git_commit_and_tag(repo / 'foo', 'first', tag=None)
+
+    initial_rev = gh._call_custom_git_cmd(repo, 'rev-parse HEAD')
+    gh._call_custom_git_cmd(repo, 'checkout -b fixup')
+    git_commit_and_tag(repo / 'foo', 'unreachable', tag='v0.0-unreachabe')
+
+    gh._call_custom_git_cmd(repo, 'checkout main')
+    git_commit_and_tag(repo / 'foo', 'second', tag='v0.1')
+
+    git_commit_and_tag(repo / 'foo', 'untagged', tag=None)
+
+    gh._call_custom_git_cmd(repo, 'checkout main')
+    git_commit_and_tag(repo / 'foo', 'third', tag='v0.2')
+
+    gh._call_custom_git_cmd(repo, f'tag v0.0-retroactive {initial_rev}')
+    assert gh.get_first_reachable_tag(repo) == 'v0.2'


### PR DESCRIPTION
Fixes #1 

Before:
```
>>> import conda_build_prepare.git_helpers
>>> conda_build_prepare.git_helpers.get_latest_describe_tag('.')
'Public_Release-7.6.0-77-g50daf8e8e069363aea2fe91cc8012a8d3038bd87'
```

After:
```
>>> import conda_build_prepare.git_helpers
>>> conda_build_prepare.git_helpers.get_latest_describe_tag('.')
'Release-7.6.0'
```